### PR TITLE
implement StageStats

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -10,6 +10,7 @@ import Rules from "./pages/Rules";
 import Mappools from "./pages/Mappools";
 import Players from "./pages/Players";
 import Schedule from "./pages/Schedule";
+import Stats from "./pages/Stats";
 import PoolHelper from "./pages/PoolHelper";
 import Navbar from "./modules/Navbar";
 import { get } from "../utilities";
@@ -86,6 +87,8 @@ export default function App() {
             path="/:year/:tourney/schedule"
             PageComponent={Schedule}
           />
+          <TourneyRouteWrapper user={user} path="/:tourney/stats" PageComponent={Stats} />
+          <TourneyRouteWrapper user={user} path="/:year/:tourney/stats" PageComponent={Stats} />
 
           <NotFound default />
         </Router>

--- a/client/src/components/modules/Navbar.js
+++ b/client/src/components/modules/Navbar.js
@@ -106,14 +106,14 @@ function TourneyNavbar(props) {
         <Menu.Item key="6">
           <Link to={`${prefix}/staff`}>{UI.staff}</Link>
         </Menu.Item>
+        <Menu.Item key="8">
+          <Link to={`${prefix}/stats`}>{UI.stats}</Link>
+        </Menu.Item>
         <SubMenu title={UI.language} className="Navbar-language">
           {languages.map((lang) => (
             <Menu.Item key={`lang-${lang}`}>{getLangName(lang)}</Menu.Item>
           ))}
         </SubMenu>
-        <Menu.Item key="8">
-          <Link to={`${prefix}/stats`}>{UI.stats}</Link>
-        </Menu.Item>
         <Menu.Item key="7">
           <LoginButton {...props} />
         </Menu.Item>

--- a/client/src/components/modules/Navbar.js
+++ b/client/src/components/modules/Navbar.js
@@ -111,6 +111,9 @@ function TourneyNavbar(props) {
             <Menu.Item key={`lang-${lang}`}>{getLangName(lang)}</Menu.Item>
           ))}
         </SubMenu>
+        <Menu.Item key="8">
+          <Link to={`${prefix}/stats`}>{UI.stats}</Link>
+        </Menu.Item>
         <Menu.Item key="7">
           <LoginButton {...props} />
         </Menu.Item>

--- a/client/src/components/modules/Qualifiers.js
+++ b/client/src/components/modules/Qualifiers.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Collapse, Form, Button, Table, DatePicker, Tag } from "antd";
+import { Collapse, Form, Button, Table, DatePicker, Tag, message } from "antd";
 import moment from "moment";
 import AddTag from "../modules/AddTag";
 import AddPlayerModal from "../modules/AddPlayerModal";
@@ -148,22 +148,27 @@ class Qualifiers extends Component {
 
   handleSubmitLobbyOk = async () => {
     this.setState({ submitLobbyModalLoading: true });
-    const newLobby = await post("/api/lobby-results", {
-      ...this.state.formData,
-      lobby: this.state.lobbyKey,
-      tourney: this.props.tourney,
-    });
+    try {
+      const newLobby = await post("/api/lobby-results", {
+        ...this.state.formData,
+        lobby: this.state.lobbyKey,
+        tourney: this.props.tourney,
+      });
 
-    this.setState((state) => ({
-      submitLobbyModalLoading: false,
-      submitLobbyModalVisible: false,
-      lobbies: state.lobbies.map((m) => {
-        if (m.key === state.lobbyKey) {
-          return { ...newLobby, key: newLobby._id };
-        }
-        return m;
-      }),
-    }));
+      this.setState((state) => ({
+        submitLobbyModalLoading: false,
+        submitLobbyModalVisible: false,
+        lobbies: state.lobbies.map((m) => {
+          if (m.key === state.lobbyKey) {
+            return { ...newLobby, key: newLobby._id };
+          }
+          return m;
+        }),
+      }));
+    } catch (e) {
+      message.error(e.message || e);
+      this.setState({ submitLobbyModalLoading: false });
+    }
   };
 
   handleSubmitLobbyValuesChange = (changed, allData) => {

--- a/client/src/components/pages/Stats.css
+++ b/client/src/components/pages/Stats.css
@@ -1,0 +1,18 @@
+.tables-container {
+  display: flex;
+}
+
+.map-stats-table {
+  margin-right: var(--m);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--m);
+}
+
+.stats-settings {
+  margin-bottom: var(--m);
+}

--- a/client/src/components/pages/Stats.js
+++ b/client/src/components/pages/Stats.js
@@ -1,0 +1,274 @@
+import React, { useState, useEffect } from "react";
+import "../../utilities.css";
+import "./Stats.css";
+import { get, post, prettifyTourney, hasAccess, getStage } from "../../utilities";
+import { Layout, Table, Menu, Form, Switch, message } from "antd";
+const { Content } = Layout;
+const { Column, ColumnGroup } = Table;
+import StageSelector from "../modules/StageSelector";
+
+export default function Stats({ tourney, user }) {
+  const [state, setState] = useState({});
+  
+  const fetchData = async () => {
+    const [tourneyModel, currentSelectedStage] = await getStage(tourney);
+    
+    const players = await get("/api/players", { tourney });
+    
+    let stageMaps = []
+    try {
+      stageMaps = await get("/api/maps", { tourney, stage: currentSelectedStage.name });
+    } catch {}
+    
+    let stageStats = {};
+    try {
+      stageStats = await get("/api/stage-stats", { tourney, stage: currentSelectedStage.name });
+    } catch {}
+    
+    // process, sort, and rank the stats for each map, while tracking overall stats
+    let overallPlayerStats = new Map();
+    let overallTeamStats = new Map();
+    const processedStats = new Map();
+    // Show empty tables instead of no tables at all if there is no data
+    stageMaps.map((stageMap) => processedStats.set(String(stageMap.mapId), { mapId: stageMap.mapId, playerScores: [], teamScores: [] }));
+    for (const mapStats of (stageStats.maps || [])) {
+      const sortedPlayerScores = [...mapStats.playerScores].sort((a, b) => a.score < b.score);
+      const sortedTeamScores = [...mapStats.teamScores].sort((a, b) => a.score < b.score);
+      const processedPlayerScores = [];
+      const processedTeamScores = [];
+      
+      let currentRank = 1;
+      let currentScore;
+      for (let i = 0; i < sortedPlayerScores.length; i++) {
+        const playerScore = sortedPlayerScores[i];
+        if (!currentScore || playerScore.score < currentScore) {
+          currentRank = i+1;
+          currentScore = playerScore.score;
+        }
+        
+        processedPlayerScores.push({...playerScore, rank: currentRank});
+        if (!overallPlayerStats.has(playerScore.userId)) overallPlayerStats.set(playerScore.userId, { rankTotal: 0, scoreTotal: 0 });
+        overallPlayerStats.get(playerScore.userId).rankTotal += currentRank;
+        overallPlayerStats.get(playerScore.userId).scoreTotal += currentScore;
+      }
+      
+      currentRank = 1;
+      currentScore = undefined;
+      for (let i = 0; i < sortedTeamScores.length; i++) {
+        const teamScore = sortedTeamScores[i];
+        if (!currentScore || teamScore.score < currentScore) {
+          currentRank = i+1;
+          currentScore = teamScore.score;
+        }
+        
+        processedTeamScores.push({...teamScore, rank: currentRank});
+        if (!overallTeamStats.has(teamScore.teamName)) overallTeamStats.set(teamScore.teamName, { rankTotal: 0, scoreTotal: 0 });
+        overallTeamStats.get(teamScore.teamName).rankTotal += currentRank;
+        overallTeamStats.get(teamScore.teamName).scoreTotal += currentScore;
+      }
+      
+      processedStats.set(String(mapStats.mapId), {...mapStats, playerScores: processedPlayerScores, teamScores: processedTeamScores});
+    }
+    
+    // sort and rank overall stats
+    overallPlayerStats = Array.from(overallPlayerStats.entries()).map(([userId, stats]) => ({...stats, userId})).sort((a, b) => a.rankTotal === b.rankTotal ? a.scoreTotal < b.scoreTotal : a.rankTotal > b.rankTotal);
+    const overallPlayerStatsWithRank = [];
+    for (let i = 0; i < overallPlayerStats.length; i++) {
+      overallPlayerStatsWithRank.push({...overallPlayerStats[i], rank: i+1});
+    }
+    overallTeamStats = Array.from(overallTeamStats.entries()).map(([teamName, stats]) => ({...stats, teamName})).sort((a, b) => a.rankTotal === b.rankTotal ? a.scoreTotal < b.scoreTotal : a.rankTotal > b.rankTotal);
+    const overallTeamStatsWithRank = [];
+    for (let i = 0; i < overallTeamStats.length; i++) {
+      overallTeamStatsWithRank.push({...overallTeamStats[i], rank: i+1});
+    }
+
+    setState({
+      tourneyModel,
+      players: new Map(players.map((player) => [player.userid, player])),
+      stageMaps,
+      stageStats,
+      processedStats,
+      overallPlayerStats: overallPlayerStatsWithRank,
+      overallTeamStats: overallTeamStatsWithRank,
+      currentSelectedMapId: "0",
+      currentSelectedStage,
+    });
+  };
+
+  useEffect(() => {
+    document.title = `${prettifyTourney(tourney)}: Stats`;
+    fetchData();
+  }, []);
+  
+  const isAdmin = () => hasAccess(user, tourney, []);
+  
+  const toggleStatsVisibility = async (visible) => {
+    await post("/api/stage", {
+      tourney,
+      stage: {...state.currentSelectedStage, statsVisible: visible},
+      index: state.currentSelectedStage.index,
+    });
+    const [tourneyModel, currentSelectedStage] = await getStage(tourney);
+    setState({...state, tourneyModel, currentSelectedStage});
+    message.success("Updated stats visibility");
+  };
+
+  return (
+    <Content className="content">
+      <div className="u-flex">
+        <div className="u-sidebar">
+          {state.currentSelectedStage && (
+            <StageSelector
+              selected={state.currentSelectedStage.index}
+              onClick={({key}) => String(state.currentSelectedStage.index) !== key ? fetchData() : {}}
+              stages={state.tourneyModel.stages}
+            />
+          )}
+        </div>
+      
+        <div>
+          {state.currentSelectedStage && isAdmin() && (
+            <div className="stats-settings">
+              <Form layout="inline">
+                <Form.Item label="Stats Visible" valuePropName="checked">
+                  <Switch checked={state.currentSelectedStage.statsVisible || false} onClick={toggleStatsVisibility}/>
+                </Form.Item>
+              </Form>
+            </div>
+          )}
+
+          <div className="topbar">
+            <Menu
+              mode="horizontal"
+              onClick={(e) => setState({...state, currentSelectedMapId: e.key})}
+              selectedKeys={[state.currentSelectedMapId]}
+            >
+              <Menu.Item key="0">Overall</Menu.Item>
+              {
+                state.stageMaps && state.stageMaps.map((stageMap) => (
+                  <Menu.Item key={stageMap.mapId}>{`${stageMap.mod}${stageMap.index}`}</Menu.Item>
+                ))
+              }
+            </Menu>
+          </div>
+
+          <div>
+            {state.currentSelectedMapId === "0" && (
+              <div className="tables-container">
+                {state.overallTeamStats.length > 0 && (
+                  <Table dataSource={ (isAdmin() || state.currentSelectedStage.statsVisible) && state.overallTeamStats } pagination={false} className="map-stats-table" bordered>
+                    <ColumnGroup title="Team Rankings">
+                      <Column
+                        title="Rank"
+                        dataIndex="rank"
+                        key="rank"
+                        render={(rank) => rank}
+                      />
+                      <Column
+                        title="Team"
+                        dataIndex="teamName"
+                        key="teamName"
+                        render={(teamName) => teamName}
+                      />
+                      <Column
+                        title="Rank Total"
+                        dataIndex="rankTotal"
+                        key="rankTotal"
+                        render={(rankTotal) => rankTotal}
+                      />
+                      <Column
+                        title="Score Total"
+                        dataIndex="scoreTotal"
+                        key="scoreTotal"
+                        render={(scoreTotal) => scoreTotal}
+                      />
+                    </ColumnGroup>
+                  </Table>
+                )}
+                <Table dataSource={ (isAdmin() || state.currentSelectedStage.statsVisible) && state.overallPlayerStats } pagination={false} className="map-stats-table" bordered>
+                  <ColumnGroup title="Player Rankings">
+                    <Column
+                      title="Rank"
+                      dataIndex="rank"
+                      key="rank"
+                      render={(rank) => rank}
+                    />
+                    <Column
+                      title="Player"
+                      dataIndex="userId"
+                      key="userId"
+                      render={(userId) => state.players.has(String(userId)) ? state.players.get(String(userId)).username : userId}
+                    />
+                    <Column
+                      title="Rank Total"
+                      dataIndex="rankTotal"
+                      key="rankTotal"
+                      render={(rankTotal) => rankTotal}
+                    />
+                    <Column
+                      title="Score Total"
+                      dataIndex="scoreTotal"
+                      key="scoreTotal"
+                      render={(scoreTotal) => scoreTotal}
+                    />
+                  </ColumnGroup>
+                </Table>
+              </div>
+            )}
+
+            {state.processedStats && state.processedStats.has(state.currentSelectedMapId) && (
+              <div className="tables-container">
+                { state.processedStats.get(state.currentSelectedMapId).teamScores.length > 0 && (
+                  <Table dataSource={ (isAdmin() || state.currentSelectedStage.statsVisible) && state.processedStats.get(state.currentSelectedMapId).teamScores } pagination={false} className="map-stats-table" bordered>
+                    <ColumnGroup title="Team Rankings">
+                      <Column
+                        title="Rank"
+                        dataIndex="rank"
+                        key="rank"
+                        render={(rank) => rank}
+                      />
+                      <Column
+                        title="Team"
+                        dataIndex="teamName"
+                        key="teamName"
+                        render={(teamName) => teamName}
+                      />
+                      <Column
+                        title="Score"
+                        dataIndex="score"
+                        key="score"
+                        render={(score) => score}
+                      />
+                    </ColumnGroup>
+                  </Table>
+                )}
+                <Table dataSource={ (isAdmin() || state.currentSelectedStage.statsVisible) && state.processedStats.get(state.currentSelectedMapId).playerScores } pagination={false} className="map-stats-table" bordered>
+                  <ColumnGroup title="Player Rankings">
+                    <Column
+                      title="Rank"
+                      dataIndex="rank"
+                      key="rank"
+                      render={(rank) => rank}
+                    />
+                    <Column
+                      title="Player"
+                      dataIndex="userId"
+                      key="userId"
+                      render={(userId) => state.players.has(String(userId)) ? state.players.get(String(userId)).username : userId}
+                    />
+                    <Column
+                      title="Score"
+                      dataIndex="score"
+                      key="score"
+                      render={(score) => score}
+                    />
+                  </ColumnGroup>
+                </Table>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </Content>
+  );
+}

--- a/client/src/content/ui.js
+++ b/client/src/content/ui.js
@@ -23,6 +23,7 @@ export default {
       tournies: "My Tournies",
     },
     archives: "Archives",
+    stats: "Stats",
   },
 
   ja: {

--- a/client/src/utilities.js
+++ b/client/src/utilities.js
@@ -60,7 +60,7 @@ export async function getStage(tourneyId) {
 
   let curIndex;
   if (!location.hash.substring(1)) {
-    curIndex = tourney.stages.filter((s) => s.poolVisible).length - 1;
+    curIndex = Math.max(0, tourney.stages.filter((s) => s.poolVisible).length - 1);
   } else {
     curIndex = parseInt(location.hash.substring(1)) || 0;
   }

--- a/server/api.js
+++ b/server/api.js
@@ -595,9 +595,10 @@ router.postAsync("/stage", ensure.isPooler, async (req, res) => {
   tourney.stages[req.body.index].poolVisible = req.body.stage.poolVisible;
 
   // Only admin is allowed to toggle stats visibility (undefined is treated as false)
+  // (Only make this check when statsVisible is set in the request)
   if (
     req.body.stage.statsVisible !== undefined &&
-    (req.body.stage.statsVisible != tourney.stages[req.body.index].statsVisible ?? false)
+    (req.body.stage.statsVisible != (tourney.stages[req.body.index].statsVisible ?? false))
   ) {
     if (!isAdmin(req.user, req.body.tourney))
       return res

--- a/server/api.js
+++ b/server/api.js
@@ -6,10 +6,11 @@ const osuApi = new osu.Api(process.env.OSU_API_KEY);
 const ensure = require("./ensure");
 const User = require("./models/user");
 const Team = require("./models/team");
-const Map = require("./models/map");
+const TourneyMap = require("./models/map");
 const Tournament = require("./models/tournament");
 const Match = require("./models/match");
 const QualifiersLobby = require("./models/qualifiers-lobby");
+const StageStats = require("./models/stage-stats");
 
 const { addAsync } = require("@awaitjs/express");
 const router = addAsync(express.Router());
@@ -145,7 +146,7 @@ router.postAsync("/map", ensure.isPooler, async (req, res) => {
   const mapData = (await osuApi.getBeatmaps({ b: req.body.id, mods: modId, m: 1, a: 1 }))[0];
 
   // all map metadata cached in our db, so we don't need to spam calls to the osu api
-  const newMap = new Map({
+  const newMap = new TourneyMap({
     ...req.body,
     mapId: parseInt(mapData.id),
     title: mapData.title,
@@ -174,7 +175,7 @@ router.postAsync("/map", ensure.isPooler, async (req, res) => {
 router.getAsync("/maps", async (req, res) => {
   const [tourney, maps] = await Promise.all([
     Tournament.findOne({ code: req.query.tourney }),
-    Map.find({ tourney: req.query.tourney, stage: req.query.stage }),
+    TourneyMap.find({ tourney: req.query.tourney, stage: req.query.stage }),
   ]);
 
   // if super hacker kiddo tries to view a pool before it's released
@@ -203,7 +204,7 @@ router.getAsync("/maps", async (req, res) => {
  */
 router.deleteAsync("/map", ensure.isPooler, async (req, res) => {
   logger.info(`${req.user.username} deleted ${req.body.id} from ${req.body.stage} pool`);
-  await Map.deleteOne({ tourney: req.body.tourney, stage: req.body.stage, _id: req.body.id });
+  await TourneyMap.deleteOne({ tourney: req.body.tourney, stage: req.body.stage, _id: req.body.id });
   res.send({});
 });
 
@@ -567,7 +568,7 @@ router.postAsync("/tournament", ensure.isAdmin, async (req, res) => {
   tourney.stages = req.body.stages.map((stage) => {
     // careful not to overwrite existing stage data
     const existing = tourney.stages.filter((s) => s.name === stage)[0];
-    return existing || { name: stage, poolVisible: false, mappack: "" };
+    return existing || { name: stage, poolVisible: false, mappack: "", statsVisible: false };
   });
 
   await tourney.save();
@@ -588,6 +589,13 @@ router.postAsync("/stage", ensure.isPooler, async (req, res) => {
   const tourney = await Tournament.findOne({ code: req.body.tourney });
   tourney.stages[req.body.index].mappack = req.body.stage.mappack;
   tourney.stages[req.body.index].poolVisible = req.body.stage.poolVisible;
+  
+  // Only admin is allowed to toggle stats visibility (undefined is treated as false)
+  if (req.body.stage.statsVisible && (req.body.stage.statsVisible != tourney.stages[req.body.index].statsVisible ?? false)) {
+    if (!isAdmin(req.user, req.body.tourney)) return res.status(403).send({ error: "You don't have permission to toggle stage stats visibility" });
+    tourney.stages[req.body.index].statsVisible = req.body.stage.statsVisible;
+  }
+  
   await tourney.save();
   res.send(tourney);
 });
@@ -1005,15 +1013,100 @@ router.deleteAsync("/lobby-player", ensure.loggedIn, async (req, res) => {
   res.send(lobby);
 });
 
+const fetchMatchAndUpdateStageStats = async (tourney, stage, mpId) => {
+  const mappool = await TourneyMap.find({ tourney, stage });
+  const stageMapIds = mappool.map((map) => map.mapId);
+  const useridToTeamMap = new Map();
+  (await Team.find({ tourney }).populate("players")).forEach((team) => team.players.forEach((player) => useridToTeamMap.set(player.userid, team.name)));
+  const tourneyPlayers = new Map();
+  (await User.find({ tournies: tourney })).forEach((player) => tourneyPlayers.set(player.userid, player));
+  let stageStats = await StageStats.findOne({ tourney, stage });
+  if (!stageStats) stageStats = { tourney, stage, maps: [] };
+  
+  const mpData = await osuApi.getMatch({ mp: mpId });
+  for (const game of mpData.games) {
+    const mapId = Number(game.beatmapId);
+    if (stageMapIds.includes(mapId)) {
+      let mapStats = stageStats.maps.find((map) => map.mapId === mapId);
+      if (!mapStats) {
+        mapStats = { mapId: mapId, playerScores: [], teamScores: [] }
+        stageStats.maps.push(mapStats);
+      }
+      const newTeamScores = new Map();
+      
+      for (const score of game.scores) {
+        // Skip tracking players that aren't registered in the tourney
+        if (!tourneyPlayers.has(score.userId)) continue;
+        
+        const playerId = Number(score.userId);
+        const newPlayerScore = { userId: playerId, score: Number(score.score) };
+        
+        // Update player high score
+        const previousPlayerScore = mapStats.playerScores.find((playerScore) => playerScore.userId === playerId);
+        if (!previousPlayerScore) {
+          mapStats.playerScores.push(newPlayerScore);
+        } else if (previousPlayerScore.score < newPlayerScore.score) {
+          mapStats.playerScores = mapStats.playerScores.map((playerScore) => {
+            if (playerScore.userId === playerId) {
+              return newPlayerScore;
+            }
+            return playerScore;
+          });
+        }
+        
+        // Add to player's team's score
+        const playerTeamName = useridToTeamMap.get(String(playerId));
+        if (playerTeamName) {
+          if (!newTeamScores.has(playerTeamName)) newTeamScores.set(playerTeamName, 0);
+          newTeamScores.set(playerTeamName, newTeamScores.get(playerTeamName) + newPlayerScore.score);
+        }
+      }
+      
+      // Update team high scores
+      for (let [teamName, teamScore] of newTeamScores.entries()) {
+        const previousTeamScore = mapStats.teamScores.find((teamScore) => teamScore.teamName === teamName);
+        const newTeamScore = { teamName, score: teamScore };
+        if (!previousTeamScore) {
+          mapStats.teamScores.push(newTeamScore);
+        } else if (previousTeamScore.score < newTeamScore.score) {
+          mapStats.teamScores = mapStats.teamScores.map((teamScore) => {
+            if (teamScore.teamName === teamName) {
+              return newTeamScore;
+            }
+            return teamScore;
+          });
+        }
+      }
+    }
+  }
+  
+  await StageStats.findOneAndUpdate(
+    { tourney, stage },
+    stageStats,
+    { upsert: true }
+  );
+}
+
 /**
  * POST /api/lobby-results
  * Submit the mp link for a qualifiers lobby
  * Params:
  *   - tourney: identifier for the tournament
- *   - key: the _id of the lobby
+ *   - lobby: the _id of the lobby
  *   - link: mp link
  */
 router.postAsync("/lobby-results", ensure.isRef, async (req, res) => {
+  logger.info(`${req.user.username} submitted mp link ${req.body.link} for qualifiers lobby ${req.body.lobby}`);
+  const regex1 = new RegExp(`^https:\/\/osu\.ppy.sh\/community\/matches\/([0-9]+)$`);
+  const regex2 = new RegExp(`^https:\/\/osu\.ppy.sh\/mp\/([0-9]+)$`);
+  const found = req.body.link.match(regex1) || req.body.link.match(regex2);
+  if (!found) {
+    logger.info("Invalid MP link");
+    return res.status(400).send({ message: "Invalid MP link" });
+  }
+  
+  await fetchMatchAndUpdateStageStats(req.body.tourney, "Qualifiers", found[1]);
+  
   const newLobby = await QualifiersLobby.findOneAndUpdate(
     { _id: req.body.lobby, tourney: req.body.tourney },
     {
@@ -1021,10 +1114,26 @@ router.postAsync("/lobby-results", ensure.isRef, async (req, res) => {
     },
     { new: true }
   );
-
-  logger.info(`${req.user.username} submitted the mp link for qualifiers lobby ${newLobby._id}`);
+  
   res.send(newLobby);
 });
+
+/**
+ * GET /api/stage-stats
+ * Get stats for a tournament stage
+ * Params:
+ *   - tourney: identifier for the tournament
+ *   - stage: identifier for the stage
+ */
+ router.getAsync("/stage-stats", async (req, res) => {
+   logger.info(`${req.user.username} requested stage stats for ${req.query.tourney} ${req.query.stage}`);
+   const tourney = await Tournament.findOne({ code: req.query.tourney });
+   if (!tourney) return res.send({});
+   const theStage = tourney.stages.find((stage) => stage.name === req.query.stage);
+   if (!isAdmin(req.user, req.query.tourney) && !theStage.statsVisible) return res.status(403).send({ error: "This stage's stats aren't released yet!" });
+   const stageStats = await StageStats.findOne({ tourney: req.query.tourney, stage: req.query.stage });
+   res.send(stageStats);
+ });
 
 /**
  * POST /api/team
@@ -1221,9 +1330,9 @@ router.getAsync("/map-history", async (req, res) => {
   const mapId = parseInt(mapData.id);
   const { title, artist, diff, creator } = mapData;
   const [sameDiff, sameSet, sameSong] = await Promise.all([
-    Map.find({ mapId }),
-    Map.find({ mapId: { $ne: mapId }, title, artist, creator }),
-    Map.find({ creator: { $ne: creator }, title, artist }),
+    TourneyMap.find({ mapId }),
+    TourneyMap.find({ mapId: { $ne: mapId }, title, artist, creator }),
+    TourneyMap.find({ creator: { $ne: creator }, title, artist }),
   ]);
 
   res.send({ sameDiff, sameSet, sameSong, mapData });

--- a/server/api.js
+++ b/server/api.js
@@ -596,7 +596,7 @@ router.postAsync("/stage", ensure.isPooler, async (req, res) => {
 
   // Only admin is allowed to toggle stats visibility (undefined is treated as false)
   if (
-    req.body.stage.statsVisible &&
+    req.body.stage.statsVisible !== undefined &&
     (req.body.stage.statsVisible != tourney.stages[req.body.index].statsVisible ?? false)
   ) {
     if (!isAdmin(req.user, req.body.tourney))

--- a/server/models/stage-stats.js
+++ b/server/models/stage-stats.js
@@ -8,7 +8,7 @@ const StageStatsSchema = new mongoose.Schema({
       mapId: Number,
       playerScores: [{ userId: Number, score: Number }],
       teamScores: [{ teamName: String, score: Number }],
-    }
+    },
   ],
 });
 

--- a/server/models/stage-stats.js
+++ b/server/models/stage-stats.js
@@ -1,0 +1,15 @@
+const mongoose = require("mongoose");
+
+const StageStatsSchema = new mongoose.Schema({
+  tourney: String,
+  stage: String,
+  maps: [
+    {
+      mapId: Number,
+      playerScores: [{ userId: Number, score: Number }],
+      teamScores: [{ teamName: String, score: Number }],
+    }
+  ],
+});
+
+module.exports = mongoose.model("StageStats", StageStatsSchema);

--- a/server/models/tournament.js
+++ b/server/models/tournament.js
@@ -9,6 +9,7 @@ const Tournament = new mongoose.Schema({
       name: String,
       poolVisible: Boolean,
       mappack: String,
+      statsVisible: Boolean,
     },
   ],
   rankMin: Number,


### PR DESCRIPTION
notes from commits:
- added StageStats model
- updated POST /lobby-results to parse mp link, fetch mp data, and store stats
- added GET /stage-stats
- updated Tournament model and POST /stage with stageStatsVisible
- renamed Map import to TourneyMap so I can use actual Map 😬
- added Stats page for fetching and displaying stage stats
- qualifier lobby MP link submission catches and displays error messages
- getStage() returns 0 index instead of -1 when no pools are visible (also fixes StageSelector showing nothing selected)

screenshot as admin:
![Screenshot 2022-03-14 13 03 53](https://user-images.githubusercontent.com/4967258/158223703-eb908071-eda6-4baa-a8aa-6c9ff96d2362.png)

screenshot as player:
![Screenshot 2022-03-14 13 05 20](https://user-images.githubusercontent.com/4967258/158223730-199046b8-9bc4-401e-a115-a75c52738278.png)