### PR TITLE
Refactor right side of navbar + language menu

### DIFF
--- a/client/src/ContentManager.js
+++ b/client/src/ContentManager.js
@@ -6,6 +6,8 @@ import { tokenizeTourney } from "./utilities";
 const _data = {};
 
 export default {
+  getLanguage: () => localStorage.getItem("lang") || "en",
+
   setLanguage: (lang) => {
     localStorage.setItem("lang", lang);
     location.reload(); // eh this is tolerable

--- a/client/src/components/modules/Navbar.css
+++ b/client/src/components/modules/Navbar.css
@@ -1,7 +1,3 @@
-.Navbar-avatar {
-  float: right;
-}
-
 .Navbar-avatar img {
   height: 50px;
   width: 50px;
@@ -9,9 +5,31 @@
   filter: drop-shadow(1px 1px 1px black);
 }
 
+.Navbar-avatar img:hover {
+  box-shadow: 0 0 12px rgba(209, 211, 221, 0.4);
+}
+
 .Navbar-Logo {
   width: 48px;
   height: 48px;
   margin: 8px 16px 8px -12px;
-  float: left;
+  /*float: left;*/
+}
+
+header.Navbar-wrapper {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 40px;
+}
+
+#Navbar-LeftNavbar {
+  display: flex;
+}
+
+#Navbar-RightNavbar .ant-menu-submenu {
+  padding: 0 16px;
+}
+
+#Navbar-RightNavbar .Navbar-lang-icon {
+  margin-right: 6px;
 }

--- a/client/src/components/modules/Navbar.css
+++ b/client/src/components/modules/Navbar.css
@@ -13,7 +13,6 @@
   width: 48px;
   height: 48px;
   margin: 8px 16px 8px -12px;
-  /*float: left;*/
 }
 
 header.Navbar-wrapper {

--- a/client/src/components/modules/Navbar.js
+++ b/client/src/components/modules/Navbar.js
@@ -9,6 +9,7 @@ import { get, post, tokenizeTourney } from "../../utilities";
 import ContentManager from "../../ContentManager";
 import GTSLogo from "../../public/gts-osu.svg";
 import YearConfig from "../../content/year-config";
+import { GlobalOutlined } from "@ant-design/icons";
 
 const { Header } = Layout;
 const { SubMenu } = Menu;
@@ -18,40 +19,82 @@ const UI = ContentManager.getUI();
 const MERCH_LINK = "https://teespring.com/stores/gtsosu-store";
 const MOUSEPAD_LINK = "https://merch.streamelements.com/gtsosu";
 
-function RootNavbar(props) {
-  const { user, openSettings } = props;
+function RightNavbar(props) {
+  const { openSettings, user, handleClick, languages } = props;
+  const getLangName = (lang) => {
+    const canonicalLang = Intl.getCanonicalLocales(lang.replace("_", "-"))[0];
+    return new Intl.DisplayNames(canonicalLang, { type: "language" }).of(canonicalLang);
+  };
+
   return (
-    <Header>
-      <Link to="/">
-        <img className="Navbar-Logo" src={GTSLogo} />
-      </Link>
-      <Menu theme="dark" mode="horizontal" selectable={false}>
-        <Menu.Item key="1">
-          <Link to="/">{UI.home}</Link>
-        </Menu.Item>
-        {/*<Menu.Item key="2">
-            <Link to="/staff">{UI.staff}</Link>*
-    </Menu.Item>*/}
-        <Menu.Item key="2">
-          <Link to="/archives">{UI.archives}</Link>
-        </Menu.Item>
-        <SubMenu title={UI.merch.title} className="Navbar-language">
-          <Menu.Item key="3.0">
-            <a href={MERCH_LINK}>{UI.merch.mainStore}</a>
-          </Menu.Item>
-          <Menu.Item key="3.1">
-            <a href={MOUSEPAD_LINK}>{UI.merch.mousepads}</a>
-          </Menu.Item>
-        </SubMenu>
-        <Menu.Item key="4">
-          <LoginButton {...props} />
-        </Menu.Item>
-        {user.username && (
-          <Menu.Item className="Navbar-avatar" key="A">
-            <img src={user.avatar} onClick={openSettings}></img>
+    <div id="Navbar-RightNavbar">
+      <Menu theme="dark" mode="horizontal" selectable={false} onClick={handleClick}>
+        {languages && (
+          <SubMenu
+            title={
+              <span>
+                <GlobalOutlined className="Navbar-lang-icon" />
+                {getLangName(ContentManager.getLanguage())}
+              </span>
+            }
+            key="lang"
+          >
+            {languages.map((lang) => (
+              <Menu.Item key={`lang-${lang}`}>{getLangName(lang)}</Menu.Item>
+            ))}
+          </SubMenu>
+        )}
+        {user.username ? (
+          <SubMenu
+            title={<img src={user.avatar} onClick={openSettings} />}
+            className="Navbar-avatar"
+            key="A"
+          >
+            <Menu.Item key="a0" onClick={openSettings}>
+              Settings
+            </Menu.Item>
+            <Menu.Item key="a1">
+              <LoginButton {...props} />
+            </Menu.Item>
+          </SubMenu>
+        ) : (
+          <Menu.Item key="4">
+            <LoginButton {...props} />
           </Menu.Item>
         )}
       </Menu>
+    </div>
+  );
+}
+
+function RootNavbar(props) {
+  return (
+    <Header className="Navbar-wrapper">
+      <div id="Navbar-LeftNavbar">
+        <Link to="/">
+          <img className="Navbar-Logo" src={GTSLogo} />
+        </Link>
+        <Menu theme="dark" mode="horizontal" selectable={false}>
+          <Menu.Item key="1">
+            <Link to="/">{UI.home}</Link>
+          </Menu.Item>
+          {/*<Menu.Item key="2">
+            <Link to="/staff">{UI.staff}</Link>*
+    </Menu.Item>*/}
+          <Menu.Item key="2">
+            <Link to="/archives">{UI.archives}</Link>
+          </Menu.Item>
+          <SubMenu title={UI.merch.title} className="Navbar-language">
+            <Menu.Item key="3.0">
+              <a href={MERCH_LINK}>{UI.merch.mainStore}</a>
+            </Menu.Item>
+            <Menu.Item key="3.1">
+              <a href={MOUSEPAD_LINK}>{UI.merch.mousepads}</a>
+            </Menu.Item>
+          </SubMenu>
+        </Menu>
+      </div>
+      <RightNavbar {...props} />
     </Header>
   );
 }
@@ -77,52 +120,37 @@ function TourneyNavbar(props) {
     });
   }, [code, year]);
 
-  const getLangName = (lang) => {
-    const canonicalLang = Intl.getCanonicalLocales(lang.replace("_", "-"))[0];
-    return new Intl.DisplayNames(canonicalLang, { type: "language" }).of(canonicalLang);
-  };
-
   return (
-    <Header>
-      <Link to="/">
-        <img className="Navbar-Logo" src={GTSLogo} />
-      </Link>
-      <Menu theme="dark" mode="horizontal" selectable={false} onClick={handleClick}>
-        <Menu.Item key="1">
-          <Link to={`${prefix}/home`}>{UI.home}</Link>
-        </Menu.Item>
-        <Menu.Item key="2">
-          <Link to={`${prefix}/rules`}>{UI.rules}</Link>
-        </Menu.Item>
-        <Menu.Item key="3">
-          <Link to={`${prefix}/pools`}>{UI.mappools}</Link>
-        </Menu.Item>
-        <Menu.Item key="4">
-          <Link to={`${prefix}/schedule`}>{UI.schedule}</Link>
-        </Menu.Item>
-        <Menu.Item key="5">
-          <Link to={`${prefix}/players`}>{UI.players}</Link>
-        </Menu.Item>
-        <Menu.Item key="6">
-          <Link to={`${prefix}/staff`}>{UI.staff}</Link>
-        </Menu.Item>
-        <Menu.Item key="8">
-          <Link to={`${prefix}/stats`}>{UI.stats}</Link>
-        </Menu.Item>
-        <SubMenu title={UI.language} className="Navbar-language">
-          {languages.map((lang) => (
-            <Menu.Item key={`lang-${lang}`}>{getLangName(lang)}</Menu.Item>
-          ))}
-        </SubMenu>
-        <Menu.Item key="7">
-          <LoginButton {...props} />
-        </Menu.Item>
-        {user.username && (
-          <Menu.Item className="Navbar-avatar" key="A">
-            <img src={user.avatar} onClick={openSettings}></img>
+    <Header className="Navbar-wrapper">
+      <div id="Navbar-LeftNavbar">
+        <Link to="/">
+          <img className="Navbar-Logo" src={GTSLogo} />
+        </Link>
+        <Menu theme="dark" mode="horizontal" selectable={false} onClick={handleClick}>
+          <Menu.Item key="1">
+            <Link to={`${prefix}/home`}>{UI.home}</Link>
           </Menu.Item>
-        )}
-      </Menu>
+          <Menu.Item key="2">
+            <Link to={`${prefix}/rules`}>{UI.rules}</Link>
+          </Menu.Item>
+          <Menu.Item key="3">
+            <Link to={`${prefix}/pools`}>{UI.mappools}</Link>
+          </Menu.Item>
+          <Menu.Item key="4">
+            <Link to={`${prefix}/schedule`}>{UI.schedule}</Link>
+          </Menu.Item>
+          <Menu.Item key="5">
+            <Link to={`${prefix}/players`}>{UI.players}</Link>
+          </Menu.Item>
+          <Menu.Item key="6">
+            <Link to={`${prefix}/staff`}>{UI.staff}</Link>
+          </Menu.Item>
+          <Menu.Item key="8">
+            <Link to={`${prefix}/stats`}>{UI.stats}</Link>
+          </Menu.Item>
+        </Menu>
+      </div>
+      <RightNavbar {...props} languages={languages} />
     </Header>
   );
 }

--- a/client/src/components/modules/Navbar.js
+++ b/client/src/components/modules/Navbar.js
@@ -84,7 +84,7 @@ function RootNavbar(props) {
           <Menu.Item key="2">
             <Link to="/archives">{UI.archives}</Link>
           </Menu.Item>
-          <SubMenu title={UI.merch.title} className="Navbar-language">
+          <SubMenu title={UI.merch.title}>
             <Menu.Item key="3.0">
               <a href={MERCH_LINK}>{UI.merch.mainStore}</a>
             </Menu.Item>


### PR DESCRIPTION
Resolves #67 

Splits the navbar into two `Menu` instead of the janky `float: right` thing before that positioned the avatar.
This also fixes a display bug where the navbar gets fucky on smaller resolutions.
Also replaces "Languages" in the navbar with the name of the language plus a globe icon