### PR TITLE
Add req.auth middleware

### DIFF
--- a/client/src/permissions/contexts/GlobalContext.js
+++ b/client/src/permissions/contexts/GlobalContext.js
@@ -1,11 +1,11 @@
 /**
  * implements PermissionContext
  */
- export class GlobalContext {
-  constructor() { }
+export class GlobalContext {
+  constructor() {}
 
   hasRole(user, role) {
-    // Admin is already handled in principal.js
+    // Admin is already handled in UserAuth.js
     return false;
   }
 }

--- a/server/api.ts
+++ b/server/api.ts
@@ -12,6 +12,7 @@ import Tournament from "./models/tournament";
 import TourneyMap from "./models/tourney-map";
 import User, { IUser } from "./models/user";
 import { getOsuApi, checkPermissions } from "./util";
+import { Request } from "./types";
 
 import mapRouter from "./api/map";
 
@@ -23,6 +24,17 @@ const router = addAsync(express.Router());
 const logger = pino();
 const osuApi = getOsuApi();
 const CONTENT_DIR = fs.readdirSync(`${__dirname}/../client/src/content`);
+
+// Populate each request with tourney-level user auth
+type BaseRequestArgs = {
+  tourney?: string;
+};
+router.use((req: Request<BaseRequestArgs, BaseRequestArgs>, res, next) => {
+  const auth = new UserAuth(req.user);
+  const tourney = req.body.tourney ?? req.query.tourney;
+  req.auth = tourney ? auth.forTourney(tourney) : auth.forGlobal();
+  next();
+});
 
 // Parts of the API are gradually being split out into separate files
 // These are the sub-routers that have been migrated/refactored

--- a/server/permissions/UserAuth.ts
+++ b/server/permissions/UserAuth.ts
@@ -1,9 +1,9 @@
-import { textChangeRangeIsUnchanged } from "typescript";
 import { IMatch } from "../models/match";
 import { ITeam, PopulatedTeam } from "../models/team";
 import { IUser } from "../models/user";
 import { Populate } from "../types";
 import { PermissionContext } from "./contexts/context";
+import { GlobalContext } from "./contexts/GlobalContext";
 import { MatchContext, MatchContextParams } from "./contexts/MatchContext";
 import { TeamContext } from "./contexts/TeamContext";
 import { TourneyContext } from "./contexts/TourneyContext";
@@ -34,6 +34,10 @@ export class UserAuth {
 
   public forTourney(tourney: string) {
     return this.withContext(new TourneyContext(tourney));
+  }
+
+  public forGlobal() {
+    return this.withContext(new GlobalContext());
   }
 }
 

--- a/server/permissions/contexts/GlobalContext.ts
+++ b/server/permissions/contexts/GlobalContext.ts
@@ -1,0 +1,12 @@
+import { IUser } from "../../models/user";
+import { UserRole } from "../UserRole";
+import { PermissionContext } from "./context";
+
+export class GlobalContext implements PermissionContext {
+  constructor() {}
+
+  public async hasRole(user: IUser, role: UserRole) {
+    // Admin is already handled in UserAuth.ts
+    return false;
+  }
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -3,6 +3,7 @@ import { Query } from "express-serve-static-core";
 
 import { IUser } from "./models/user";
 import { HydratedDocument } from "mongoose";
+import { UserAuthWithContext } from "./permissions/UserAuth";
 
 // User interface + mongoose document builtins (e.g. _id, .save())
 // This added to the base express Request object as req.user
@@ -11,6 +12,7 @@ interface Request<Q extends Query, B> extends express.Request {
   query: Q;
   body: B;
   user?: UserDocument;
+  auth: UserAuthWithContext;
 }
 type Populate<T, R> = Omit<T, keyof R> & R;
 


### PR DESCRIPTION
Most routes expect a `tourney` arg, so it might make sense to pre-populate a `req.auth` object whose default context is TourneyContext. That way, routes could do stuff along the lines of this:

```
router.post("/register", async (req, res) => {
  if (await req.auth.hasAnyRole(STAFF_ROLES)) {
    return res.status(400).send({error: "You're a staff member"};
  }
  ...
});

```