### PR TITLE
Make permissions library synchronous

### DIFF
--- a/client/src/permissions/contexts/MatchContext.js
+++ b/client/src/permissions/contexts/MatchContext.js
@@ -23,7 +23,7 @@ export class MatchContext {
 
   /**
    * @type {TourneyContext}
-   * 
+   *
    * For forwarding non player/captain roles to tourney context
    */
   _tourneyContext;
@@ -31,7 +31,7 @@ export class MatchContext {
   hasRole = undefined;
 
   /**
-   * @param {Match} match 
+   * @param {Match} match
    * @param {number | undefined} playerNo If undefined, this will check for both teams/players, and vice versa
    * @param {Map<string, Team> | Team[]} teams Teams data, leave undefined in the case of individual tournies
    */
@@ -57,8 +57,8 @@ export class MatchContext {
 
   /**
    * hasRole for individual tournies
-   * 
-   * @param {User} user 
+   *
+   * @param {User} user
    * @param {string} role
    * @returns {boolean}
    */
@@ -68,14 +68,9 @@ export class MatchContext {
       case UserRole.Captain:
       case UserRole.Player:
         if (this._playerNo) {
-          if (this._match[`player${this._playerNo}`] === user.username) {
-            return true;
-          }
+          return this._match[`player${this._playerNo}`] === user.username;
         } else {
-          if (this._match.player1 === user.username || this._match.player2 === user.username) {
-            return true;
-          }
-
+          return this._match.player1 === user.username || this._match.player2 === user.username;
         }
       default:
         return this._tourneyContext.hasRole(user, role);
@@ -84,8 +79,8 @@ export class MatchContext {
 
   /**
    * hasRole for team tournies
-   * 
-   * @param {User} user 
+   *
+   * @param {User} user
    * @param {string} role
    * @returns {boolean}
    */
@@ -104,7 +99,6 @@ export class MatchContext {
       default:
         return this._tourneyContext.hasRole(user, role);
     }
-
   }
 
   getTeam(playerNo) {

--- a/server/api.ts
+++ b/server/api.ts
@@ -68,7 +68,7 @@ const canEditWarmup = async (user: IUser, playerNo: 1 | 2, match: IMatch) => {
   if (match.time.getTime() - Date.now() < 3600000) return false;
 
   const teams = await getTeamMapForMatch(match, playerNo);
-  return new UserAuth(user).forMatch(match, playerNo, teams).hasRole(UserRole.Captain);
+  return new UserAuth(user).forMatch({ match, playerNo, teams }).hasRole(UserRole.Captain);
 };
 
 const parseWarmup = async (warmup: string) => {

--- a/server/api.ts
+++ b/server/api.ts
@@ -67,8 +67,8 @@ const canEditWarmup = async (user: IUser, playerNo: 1 | 2, match: IMatch) => {
   // Players can't edit if the match is in less than 1 hour
   if (match.time.getTime() - Date.now() < 3600000) return false;
 
-  const teams = getTeamMapForMatch(match, playerNo);
-  return new UserAuth(user).forMatch(match, playerNo).hasRole(UserRole.Captain);
+  const teams = await getTeamMapForMatch(match, playerNo);
+  return new UserAuth(user).forMatch(match, playerNo, teams).hasRole(UserRole.Captain);
 };
 
 const parseWarmup = async (warmup: string) => {

--- a/server/api.ts
+++ b/server/api.ts
@@ -540,7 +540,7 @@ router.postAsync("/match", ensure.isAdmin, async (req, res) => {
  */
 router.postAsync("/warmup", ensure.loggedIn, async (req, res) => {
   const match = await Match.findOne({ _id: req.body.match }).orFail();
-  if (!(await canEditWarmup(req.auth, req.body.playerNo, match))) {
+  if (!(await canEditWarmup(req.user, req.body.playerNo, match))) {
     logger.warn(
       `${req.user.username} tried to submit player ${req.body.playerNo} warmup for ${req.body.match}`
     );

--- a/server/api/map.ts
+++ b/server/api/map.ts
@@ -32,7 +32,7 @@ const scaleDiff = (diff: number, mod: string) => {
 };
 
 const canViewHiddenPools = async (user: IUser | undefined, tourney: string) =>
-  await checkPermissions(user, tourney, [
+  checkPermissions(user, tourney, [
     "Mapsetter",
     "Showcase",
     "All-Star Mapsetter",
@@ -107,7 +107,7 @@ mapRouter.getAsync(
 
     // if super hacker kiddo tries to view a pool before it's released
     const stageData = tourney.stages.filter((s) => s.name === req.query.stage)[0];
-    if (!stageData.poolVisible && !(await canViewHiddenPools(req.user, req.query.tourney))) {
+    if (!stageData.poolVisible && !canViewHiddenPools(req.user, req.query.tourney)) {
       res.status(403).send({ error: "This pool hasn't been released yet!" });
       return;
     }

--- a/server/permissions/UserAuth.ts
+++ b/server/permissions/UserAuth.ts
@@ -4,7 +4,7 @@ import { IUser } from "../models/user";
 import { Populate } from "../types";
 import { PermissionContext } from "./contexts/context";
 import { GlobalContext } from "./contexts/GlobalContext";
-import { MatchContext, TeamMap } from "./contexts/MatchContext";
+import { MatchContext, MatchContextParams } from "./contexts/MatchContext";
 import { TeamContext } from "./contexts/TeamContext";
 import { TourneyContext } from "./contexts/TourneyContext";
 import { UserRole } from "./UserRole";
@@ -24,8 +24,8 @@ export class UserAuth {
     return new UserAuthWithContext(this.user, context);
   }
 
-  public forMatch(match: IMatch, playerNo?: 1 | 2, teams?: TeamMap) {
-    return this.withContext(new MatchContext(match, playerNo, teams));
+  public forMatch(params: MatchContextParams) {
+    return this.withContext(new MatchContext(params));
   }
 
   public forTeam(team: Populate<ITeam, PopulatedTeam>) {

--- a/server/permissions/UserAuth.ts
+++ b/server/permissions/UserAuth.ts
@@ -4,7 +4,7 @@ import { IUser } from "../models/user";
 import { Populate } from "../types";
 import { PermissionContext } from "./contexts/context";
 import { GlobalContext } from "./contexts/GlobalContext";
-import { MatchContext, MatchContextParams } from "./contexts/MatchContext";
+import { MatchContext, TeamMap } from "./contexts/MatchContext";
 import { TeamContext } from "./contexts/TeamContext";
 import { TourneyContext } from "./contexts/TourneyContext";
 import { UserRole } from "./UserRole";
@@ -24,8 +24,8 @@ export class UserAuth {
     return new UserAuthWithContext(this.user, context);
   }
 
-  public forMatch(match: IMatch, params: MatchContextParams) {
-    return this.withContext(new MatchContext(match, params));
+  public forMatch(match: IMatch, playerNo?: 1 | 2, teams?: TeamMap) {
+    return this.withContext(new MatchContext(match, playerNo, teams));
   }
 
   public forTeam(team: Populate<ITeam, PopulatedTeam>) {
@@ -48,54 +48,27 @@ const SUPER_ROLES = [UserRole.Host, UserRole.Developer];
 
 export class UserAuthWithContext extends UserAuth {
   private context: PermissionContext;
-
-  // Do not access these directly -- use hasSuperRole()
-  private _superRoleLoaded: boolean = false;
-  private _hasSuperRole: boolean = false;
+  private hasSuperRole: boolean;
 
   constructor(user: IUser | undefined, context: PermissionContext) {
     super(user);
     this.context = context;
+    this.hasSuperRole =
+      !!user && (user.admin || SUPER_ROLES.some((role) => this.context.hasRole(user, role)));
   }
 
-  private async hasSuperRole() {
-    const user = this.user;
-    if (!user) return false;
-    if (user.admin) return true;
-    if (this._superRoleLoaded) return this._hasSuperRole;
-
-    this._hasSuperRole = await Promise.all(
-      SUPER_ROLES.map((role) => this.context.hasRole(user, role))
-    ).then((results) => results.some((result) => result));
-
-    this._superRoleLoaded = true;
-    return this._hasSuperRole;
-  }
-
-  public async hasRole(role: UserRole) {
+  public hasRole(role: UserRole) {
     if (!this.user) return false;
-    if (await this.hasSuperRole()) return true;
+    if (this.hasSuperRole) return true;
 
     return this.context.hasRole(this.user, role);
   }
 
-  public async hasAllRoles(roles: UserRole[]) {
-    if (!this.user) return false;
-    if (await this.hasSuperRole()) return true;
-
-    for (const role of roles) {
-      if (!(await this.context.hasRole(this.user, role))) return false;
-    }
-    return true;
+  public hasAllRoles(roles: UserRole[]) {
+    return roles.every((role) => this.hasRole(role));
   }
 
-  public async hasAnyRole(roles: UserRole[]) {
-    if (!this.user) return false;
-    if (await this.hasSuperRole()) return true;
-
-    for (const role of roles) {
-      if (await this.context.hasRole(this.user, role)) return true;
-    }
-    return false;
+  public hasAnyRole(roles: UserRole[]) {
+    return roles.some((role) => this.hasRole(role));
   }
 }

--- a/server/permissions/contexts/GlobalContext.ts
+++ b/server/permissions/contexts/GlobalContext.ts
@@ -5,7 +5,7 @@ import { PermissionContext } from "./context";
 export class GlobalContext implements PermissionContext {
   constructor() {}
 
-  public async hasRole(user: IUser, role: UserRole) {
+  public hasRole(user: IUser, role: UserRole) {
     // Admin is already handled in UserAuth.ts
     return false;
   }

--- a/server/permissions/contexts/MatchContext.ts
+++ b/server/permissions/contexts/MatchContext.ts
@@ -7,41 +7,40 @@ import { UserRole } from "../UserRole";
 import { TourneyContext } from "./TourneyContext";
 import { TeamContext } from "./TeamContext";
 import { Populate } from "../../types";
+import { getPlayerName } from "../../util";
+import assert from "assert";
 
-export type MatchContextParams = {
-  tourney?: ITournament;
-  teams?: { [team: string]: Populate<ITeam, PopulatedTeam> };
-  playerNo?: 1 | 2;
-};
+export type TeamMap = { [team: string]: Populate<ITeam, PopulatedTeam> };
 
 export class MatchContext implements PermissionContext {
   private match: IMatch;
-  private teamCache: { [team: string]: Populate<ITeam, PopulatedTeam> } = {};
+  private teams?: TeamMap;
   private playerNo?: 1 | 2;
-  /**
-   * Do not use this directly, use getTourney instead.
-   */
-  private tourneyCache?: ITournament;
   private tourneyContext: TourneyContext;
 
-  constructor(match: IMatch, params: MatchContextParams) {
+  /**
+   * @param match Mongo object for the match
+   * @param playerNo If undefined, this will check for both teams/players, and vice versa
+   * @param teams Teams data, leave undefined in the case of individual tournies
+   */
+  constructor(match: IMatch, playerNo?: 1 | 2, teams?: TeamMap) {
     this.match = match;
-    this.tourneyCache = params.tourney;
-    this.teamCache = params.teams || {};
-    this.playerNo = params.playerNo;
+    this.teams = teams;
+    this.playerNo = playerNo;
+    this.tourneyContext = new TourneyContext(match.tourney);
   }
 
-  public async hasRole(user: IUser, role: UserRole) {
-    const tourney = await this.getTourney();
-    return tourney.teams ? this.hasRoleTeam(user, role) : this.hasRoleIndividual(user, role);
+  public hasRole(user: IUser, role: UserRole) {
+    return !!this.teams ? this.hasRoleTeam(user, role) : this.hasRoleIndividual(user, role);
   }
 
-  private async hasRoleIndividual(user: IUser, role: UserRole) {
+  private hasRoleIndividual(user: IUser, role: UserRole) {
+    assert(!this.teams);
     switch (role) {
       case UserRole.Captain:
       case UserRole.Player:
         if (this.playerNo) {
-          return this.match[`player${this.playerNo}`] === user.username;
+          return getPlayerName(this.match, this.playerNo) === user.username;
         } else {
           return this.match.player1 === user.username || this.match.player2 === user.username;
         }
@@ -50,40 +49,28 @@ export class MatchContext implements PermissionContext {
     }
   }
 
-  private async hasRoleTeam(user: IUser, role: UserRole) {
+  private hasRoleTeam(user: IUser, role: UserRole) {
+    assert(this.teams);
     switch (role) {
       case UserRole.Player:
       case UserRole.Captain:
         if (this.playerNo) {
-          const team = await this.getTeam(this.playerNo);
+          const team = this.getTeam(this.playerNo);
           if (!team) return false;
           return new TeamContext(team).hasRole(user, role);
+        } else {
+          const allTeams = [this.getTeam(1), this.getTeam(2)];
+          return allTeams.some((team) => team && new TeamContext(team).hasRole(user, role));
         }
       default:
         return this.tourneyContext.hasRole(user, role);
     }
   }
 
-  private async getTeam(playerNo: 1 | 2) {
-    const team = this.match[`player${playerNo}`];
-
-    if (!this.teamCache[team]) {
-      this.teamCache[team] = await Team.findOne({ name: team })
-        .orFail()
-        .populate<PopulatedTeam>("players");
+  private getTeam(playerNo: 1 | 2) {
+    if (this.teams) {
+      return this.teams[getPlayerName(this.match, playerNo)];
     }
-    return this.teamCache[team];
-  }
-
-  /**
-   * Returns the tourney for this match, fetching it if necessary.
-   */
-  private async getTourney() {
-    if (!this.tourneyCache) {
-      this.tourneyCache = await Tournament.findOne({ code: this.match.tourney }).orFail();
-      this.tourneyContext = new TourneyContext(this.match.tourney);
-    }
-
-    return this.tourneyCache!;
+    return null;
   }
 }

--- a/server/permissions/contexts/MatchContext.ts
+++ b/server/permissions/contexts/MatchContext.ts
@@ -10,20 +10,21 @@ import { Populate } from "../../types";
 import { getPlayerName } from "../../util";
 import assert from "assert";
 
-export type TeamMap = { [team: string]: Populate<ITeam, PopulatedTeam> };
+export type MatchContextParams = {
+  match: IMatch;
+  /** If undefined, this will check for both teams/players */
+  playerNo?: 1 | 2;
+  /** Teams data, leave undefined in the case of individual tourneys */
+  teams?: { [team: string]: Populate<ITeam, PopulatedTeam> };
+};
 
 export class MatchContext implements PermissionContext {
   private match: IMatch;
-  private teams?: TeamMap;
+  private teams?: { [team: string]: Populate<ITeam, PopulatedTeam> };
   private playerNo?: 1 | 2;
   private tourneyContext: TourneyContext;
 
-  /**
-   * @param match Mongo object for the match
-   * @param playerNo If undefined, this will check for both teams/players, and vice versa
-   * @param teams Teams data, leave undefined in the case of individual tournies
-   */
-  constructor(match: IMatch, playerNo?: 1 | 2, teams?: TeamMap) {
+  constructor({ match, playerNo, teams }: MatchContextParams) {
     this.match = match;
     this.teams = teams;
     this.playerNo = playerNo;

--- a/server/permissions/contexts/TeamContext.ts
+++ b/server/permissions/contexts/TeamContext.ts
@@ -11,7 +11,7 @@ export class TeamContext implements PermissionContext {
     this.team = team;
   }
 
-  public async hasRole(user: IUser, role: UserRole) {
+  public hasRole(user: IUser, role: UserRole) {
     switch (role) {
       case UserRole.Captain:
         return this.team.players[0].username === user.username;

--- a/server/permissions/contexts/TourneyContext.ts
+++ b/server/permissions/contexts/TourneyContext.ts
@@ -9,7 +9,7 @@ export class TourneyContext implements PermissionContext {
     this.tourney = tourney;
   }
 
-  public async hasRole(user: IUser, role: UserRole) {
+  public hasRole(user: IUser, role: UserRole) {
     return user.roles.some((r) => r.tourney === this.tourney && r.role === role.toString());
   }
 }

--- a/server/permissions/contexts/context.ts
+++ b/server/permissions/contexts/context.ts
@@ -2,5 +2,5 @@ import { IUser } from "../../models/user";
 import { UserRole } from "../UserRole";
 
 export interface PermissionContext {
-  hasRole: (user: IUser, role: UserRole) => Promise<boolean>;
+  hasRole: (user: IUser, role: UserRole) => boolean;
 }

--- a/server/util.ts
+++ b/server/util.ts
@@ -4,7 +4,10 @@ import { IUser } from "./models/user";
 import { UserAuth } from "./permissions/UserAuth";
 import { UserRole } from "./permissions/UserRole";
 import { Request, UserDocument } from "./types";
+import Team, { PopulatedTeam } from "./models/team";
+import Tournament from "./models/tournament";
 import assert from "assert";
+import { IMatch } from "./models/match";
 
 // Shared utilities used across the backend
 
@@ -22,4 +25,31 @@ export const assertUser = (req: Request<any, any>): UserDocument => {
   assert(req.user);
   assert(req.user._id);
   return req.user;
+};
+
+export const getPlayerName = (match: IMatch, playerNo: 1 | 2) => match[`player${playerNo}`];
+
+// Returns a mapping from {teamName: teamObject} if the match has teams, or undefined otherwise
+export const getTeamMapForMatch = async (match: IMatch, playerNo?: 1 | 2) => {
+  const tourney = await Tournament.findOne({ code: match.tourney }).orFail();
+  if (!tourney.teams) {
+    return undefined;
+  }
+
+  const getTeam = (name: string) =>
+    Team.findOne({ name }).orFail().populate<PopulatedTeam>("players");
+
+  if (playerNo) {
+    const name = getPlayerName(match, playerNo);
+    return { [name]: await getTeam(name) };
+  }
+
+  const teams = await Promise.all([
+    getTeam(getPlayerName(match, 1)),
+    getTeam(getPlayerName(match, 2)),
+  ]);
+  return {
+    [getPlayerName(match, 1)]: teams[0],
+    [getPlayerName(match, 2)]: teams[1],
+  };
 };


### PR DESCRIPTION
Makes the backend permission library synchronous. This has the following benefits

- Makes the backend's permissions API consistent with the frontend's
- Eliminates the need to await permissions checks that are actually synchronous
- Makes checks safer from bugs by avoiding `Promise<boolean>` (this could be checked by an eslint rule, but better to make it impossible to happen in the first place)
- Simplifies the implementation of permissions library