### PR TITLE
some improvements to stats page

### DIFF
--- a/client/src/components/pages/Stats.css
+++ b/client/src/components/pages/Stats.css
@@ -21,3 +21,18 @@
   margin-right: var(--m);
 }
 
+.seed-1 {
+  background-color: #f4cccc;
+}
+
+.seed-2 {
+  background-color: #fff2cc;
+}
+
+.seed-3 {
+  background-color: #d9ead3;
+}
+
+.seed-4 {
+  background-color: #cfe2f3;
+}


### PR DESCRIPTION
- display flags
- determine seed and color rows (only for qualifiers stage)
- add avg rank columns
- add avg scores per map
- add a second topbar for switching between team and player ranking tables

![Screenshot 2022-03-26 12 58 22](https://user-images.githubusercontent.com/4967258/160249856-0807e223-fcf2-4218-965a-61b6a6c0ccbe.png)