### PR TITLE
fix mapStats not updating if it's newly created

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -973,15 +973,13 @@ const fetchMatchesAndUpdateStageStats = async (tourney, stage, mpIds) => {
 
   for (const mpId of mpIds) {
     const mpData = await osuApi.getMatch({ mp: mpId });
-    logger.info(mpData);
     for (const game of mpData.games) {
       const mapId = Number(game.beatmapId);
       if (stageMapIds.includes(mapId)) {
-        let mapStats = stageStats.maps.find((map) => map.mapId === mapId);
-        if (!mapStats) {
-          mapStats = { mapId: mapId, playerScores: [], teamScores: [] };
-          stageStats.maps.push(mapStats);
+        if (!stageStats.maps.find((map) => map.mapId === mapId)) {
+          stageStats.maps.push({ mapId: mapId, playerScores: [], teamScores: [] });
         }
+        const mapStats = stageStats.maps.find((map) => map.mapId === mapId)!;
         const newTeamScores = new Map();
 
         for (const score of game.scores) {


### PR DESCRIPTION
(idk why I need this ???)

what was happening in the previous code:
```
        let mapStats = stageStats.maps.find((map) => map.mapId === mapId);
        if (!mapStats) {
          mapStats = { mapId: mapId, playerScores: [], teamScores: [] }; // this instance of mapStats is updated properly by the end of the loop
          stageStats.maps.push(mapStats); // the mapStats that is pushed to stageStats.maps ends up not getting updated for some reason, even though it should be the same instance
        }
```