### PR TITLE
Various adjustments to new theme

### DIFF
--- a/client/src/components/App.less
+++ b/client/src/components/App.less
@@ -5,6 +5,7 @@
 @greyts: #b5c8d6;
 @onyxdark: #31373f;
 @darknight: #2e3135;
+@darkernight: #131415;
 @purewhite: #ffffff;
 
 @primary-color: @gtsorange;
@@ -17,10 +18,10 @@
 @heading-color: @purewhite;
 @background-color-light: @darknight;
 @icon-color: @purewhite;
-@border-color-base: @greyts;
-@border-color-split: black;
+@border-color-base: @darkernight;
+@border-color-split: @darkernight;
 @item-hover-bg: @greyts;
 @disabled-bg: @onyxdark;
-@disabled-color: black;
+@disabled-color: @darkernight;
 @btn-disable-color: @greyts;
 @select-selection-item-bg: @onyxdark;

--- a/client/src/components/App.less
+++ b/client/src/components/App.less
@@ -18,7 +18,7 @@
 @heading-color: @purewhite;
 @background-color-light: @darknight;
 @icon-color: @purewhite;
-@border-color-base: @darkernight;
+@border-color-base: @greyts;
 @border-color-split: @darkernight;
 @item-hover-bg: @greyts;
 @disabled-bg: @onyxdark;

--- a/client/src/components/modules/FlagIcon.css
+++ b/client/src/components/modules/FlagIcon.css
@@ -1,5 +1,5 @@
 .FlagIcon-img {
   height: 22px;
-  box-shadow: 0 0 3px black;
+  box-shadow: 0 0 3px var(--darker-night);
   border-radius: 18%;
 }

--- a/client/src/components/modules/MapCard.css
+++ b/client/src/components/modules/MapCard.css
@@ -2,7 +2,7 @@
   margin: var(--m);
   max-width: 600px;
   flex-basis: 400px;
-  box-shadow: 0 0 12px black;
+  box-shadow: 0 0 12px var(--darker-night);
 }
 
 .MapCard-card a img {
@@ -66,7 +66,11 @@
 
 .MapCard-small {
   font-size: 11pt;
-  color: rgb(125, 125, 125);
+  color: var(--greyts);
+}
+
+.MapCard-attr .anticon {
+  color: var(--white);
 }
 
 /* Colors for mod icons */

--- a/client/src/components/modules/MapCard.js
+++ b/client/src/components/modules/MapCard.js
@@ -1,9 +1,9 @@
 import React, { Component } from "react";
 import {
   DeleteOutlined,
-  StarTwoTone,
-  ClockCircleTwoTone,
-  DashboardTwoTone,
+  StarOutlined,
+  ClockCircleOutlined,
+  DashboardOutlined,
   DownloadOutlined,
 } from "@ant-design/icons";
 import CustomMapBadge from "../../public/custom-map-badge.svg";
@@ -86,13 +86,13 @@ export default function MapCard({
 
       <div className="MapCard-attr-row">
         <div className="MapCard-attr">
-          <StarTwoTone /> {sr}
+          <StarOutlined /> {sr}
         </div>
         <div className="MapCard-attr">
-          <ClockCircleTwoTone /> {length}
+          <ClockCircleOutlined /> {length}
         </div>
         <div className="MapCard-attr">
-          <DashboardTwoTone /> {bpm}bpm
+          <DashboardOutlined /> {bpm}bpm
         </div>
       </div>
 

--- a/client/src/components/modules/Navbar.css
+++ b/client/src/components/modules/Navbar.css
@@ -2,7 +2,7 @@
   height: 50px;
   width: 50px;
   border-radius: 50%;
-  filter: drop-shadow(1px 1px 1px black);
+  filter: drop-shadow(1px 1px 1px var(--darker-night));
 }
 
 .Navbar-avatar img:hover {
@@ -19,7 +19,7 @@ header.Navbar-wrapper {
   display: flex;
   justify-content: space-between;
   padding: 0 40px;
-  background: var(--white);
+  background: var(--darker-night);
 }
 
 #Navbar-LeftNavbar {
@@ -32,21 +32,23 @@ header.Navbar-wrapper {
 
 #Navbar-RightNavbar .Navbar-lang-icon {
   margin-right: 6px;
+  color: var(--greyts);
 }
 
 header.Navbar-wrapper .ant-menu {
-  background: var(--white);
-  color: var(--night);
+  background: var(--darker-night);
+  color: var(--greyts);
 }
 
 header.Navbar-wrapper .ant-menu-item {
-  font-size: 16px;
-  background: var(--white);
-  color: var(--night);
+  font-size: 15px;
+  font-weight: 500;
+  background: var(--darker-night);
+  color: var(--greyts);
 }
 
 header.Navbar-wrapper .ant-menu-item > a {
-  color: var(--night);
+  color: var(--greyts);
   text-transform: uppercase;
 }
 
@@ -56,13 +58,14 @@ header.Navbar-wrapper .ant-menu-submenu .ant-menu-submenu-title {
 
 @media (min-width: 1500px) {
   header.Navbar-wrapper .ant-menu-dark.ant-menu-horizontal > .ant-menu-item {
-    padding: 0 40px;
+    padding: 0 32px;
   }
 }
 
 
 .ant-menu-submenu-title {
   font-size: 15px;
+  font-weight: 500;
 }
 
 header.Navbar-wrapper .ant-menu-submenu-horizontal.ant-menu-submenu:not(.Navbar-avatar):hover {
@@ -71,5 +74,13 @@ header.Navbar-wrapper .ant-menu-submenu-horizontal.ant-menu-submenu:not(.Navbar-
 }
 
 header.Navbar-wrapper .anticon {
-  color: var(--night);
+  color: var(--darker-night);
+}
+
+header.Navbar-wrapper .ant-menu-submenu {
+  background-color: var(--darker-night);
+}
+
+.ant-menu-submenu-popup > .ant-menu {
+  background-color: var(--darker-night)!important;
 }

--- a/client/src/components/modules/Navbar.js
+++ b/client/src/components/modules/Navbar.js
@@ -31,6 +31,7 @@ function RightNavbar(props) {
       <Menu theme="dark" mode="horizontal" selectable={false} onClick={handleClick}>
         {languages && (
           <SubMenu
+            className="submenu"
             title={
               <span>
                 <GlobalOutlined className="Navbar-lang-icon" />

--- a/client/src/components/modules/StageSelector.css
+++ b/client/src/components/modules/StageSelector.css
@@ -1,6 +1,6 @@
 .ant-menu-root.ant-menu.stage-selector {
   background-color: var(--night);
-  border: 1px solid black;
+  border: 1px solid var(--darker-night);
 }
 
 .ant-menu-item-selected.stage-name a {

--- a/client/src/components/modules/TeamCard.css
+++ b/client/src/components/modules/TeamCard.css
@@ -1,14 +1,14 @@
 .TeamCard-container {
-  border: 1px solid black;
+  border: 1px solid var(--darker-night);
   margin: var(--m);
-  box-shadow: 2px 2px 8px black;
+  box-shadow: 2px 2px 8px var(--darker-night);
   display: flex;
 }
 
 .TeamCard-seed {
   margin: var(--xs);
   width: var(--xs);
-  box-shadow: 1px 1px 4px black;
+  box-shadow: 1px 1px 4px var(--darker-night);
 }
 
 .TeamCard-head-wrapper {

--- a/client/src/components/modules/UserCard.css
+++ b/client/src/components/modules/UserCard.css
@@ -1,9 +1,9 @@
 .UserCard-outside {
-  border: 1px solid black;
+  border: 1px solid var(--darker-night);
   display: grid;
   grid-template-columns: 75px 350px;
   grid-template-rows: 75px;
-  box-shadow: 2px 2px 8px black;
+  box-shadow: 2px 2px 8px var(--darker-night);
   width: 428px;
   margin: var(--s);
 }

--- a/client/src/components/pages/Archives.css
+++ b/client/src/components/pages/Archives.css
@@ -1,7 +1,21 @@
 .Archives-container {
   max-width: 500px;
+  background-color: var(--night);
 }
 
 .Archives-entry {
-  color: rgb(17, 125, 226);
+  color: var(--greyts);
+  font-size: 15px;
+  font-weight: 500;
+  width: 100%;
+}
+
+.Archives-entry:hover {
+  color: var(--white);
+}
+
+.Archives-entry-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 100%;
 }

--- a/client/src/components/pages/Archives.js
+++ b/client/src/components/pages/Archives.js
@@ -42,9 +42,11 @@ function Archives(props) {
           loading={!tourneys.length}
           renderItem={(tourney) => (
             <List.Item key={tourney._id}>
-              <Link to={`/${tourney.year}/${tourney.codeAndDivision}/home`}>
-                <span className="Archives-entry">{tourney.displayName}</span>
-              </Link>
+              <div className="Archives-entry-wrapper">
+                <Link to={`/${tourney.year}/${tourney.codeAndDivision}/home`}>
+                  <span className="Archives-entry">{tourney.displayName}</span>
+                </Link>
+              </div>
             </List.Item>
           )}
         />

--- a/client/src/components/pages/Mappools.css
+++ b/client/src/components/pages/Mappools.css
@@ -5,7 +5,7 @@
 
 .Mappools-pack {
   margin-top: var(--m);
-  border: 1px solid black;
+  border: 1px solid var(--darker-night);
   text-align: center;
   padding: var(--xs);
 }

--- a/client/src/global.css
+++ b/client/src/global.css
@@ -8,6 +8,7 @@
   --white: #fff;
   --bg: #f0f2f5;
   --gold: #ffc53b;
+  --darker-night: #131415;
 
   --xs: 4px;
   --s: 8px;
@@ -116,7 +117,7 @@ body .ant-table {
 }
 
 body .ant-card-bordered {
-  border: 1px solid black;
+  border: 1px solid var(--darker-night);
 }
 
 body .ant-card-bordered .ant-card-cover {


### PR DESCRIPTION
Changelog:

- Change navbar color to a darker version of dark night. I hesitate to add a new color, but I couldn't find any good looking alternatives within our current color pallet.
- Reduce spacing a bit, and spacing will automatically shrink spacing more more on narrower windows (3d4f4b7ff749fcfc23e7b09f9d927df522430897) 
![image](https://user-images.githubusercontent.com/8433005/192207924-1b672726-188a-4f12-8205-df0256848a5a.png)

- Instead of pure black, using `darker-night` for borders/shadows which is slightly more subtle
- Change mapcard secondary text to use our secondary color (`greyts`)
- Change SR/length/BPM icons to use the color scheme
![image](https://user-images.githubusercontent.com/8433005/192206452-18c38ed5-0a67-4009-9267-961fd3741107.png)
(New vs old version)

- Touch up the archives page a bit (still doesn't look great)
![image](https://user-images.githubusercontent.com/8433005/192207651-df0fbbf7-1b80-49bc-9659-8579e574807e.png)
