### PR TITLE
add a mod filter for freemod stats

### DIFF
--- a/client/src/components/pages/Stats.css
+++ b/client/src/components/pages/Stats.css
@@ -1,3 +1,7 @@
+.page-content {
+  width: 100%;
+}
+
 .tables-container {
   display: flex;
 }
@@ -15,6 +19,17 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: var(--m);
+  height: 48px;
+}
+
+.mod-filter {
+  margin-left: auto;
+}
+
+.mod-filter-label {
+  font-size: 12pt;
+  font-weight: bold;
+  margin-right: var(--s);
 }
 
 .stats-settings {


### PR DESCRIPTION
![Screenshot 2022-11-16 03 01 12](https://user-images.githubusercontent.com/4967258/202122430-bfc7576a-773d-492e-b7c8-c8ce99a77a91.png)

![Screenshot 2022-11-16 03 02 19](https://user-images.githubusercontent.com/4967258/202122448-75888d0c-356f-41aa-812b-e36272ce0f65.png)

Notes: I put the mod filter selector on the same line as the team/player table selector, with margin-left:auto to keep it on the right side in case the team/player table selector isn't there. It also only appears when applicable, i.e. FM or TB picks. I added height:48px so that the stuff below doesn't suddenly shift upwards when the mod filter selector disappears.