### PR TITLE
replaced team/player tooltips with card popovers

### DIFF
--- a/client/src/components/modules/EditTourneyModal.js
+++ b/client/src/components/modules/EditTourneyModal.js
@@ -1,7 +1,7 @@
 import React from "react";
 import countries from "../../content/countries";
 
-import { Form, Modal, InputNumber, Select, Switch } from "antd";
+import { Form, Modal, InputNumber, Select, Switch, Input } from "antd";
 
 const stages = [
   "Qualifiers",
@@ -76,6 +76,10 @@ export default function EditTourneyModal({
         <Form.Item name="lobbyMaxSignups" label="Maximum number of lobby signups">
           <InputNumber min={0} />
         </Form.Item>
+        <Form.Item name="blacklist" label="Blacklist">
+          <Input />
+        </Form.Item>
+        <span>(Specify players by IDs separated by commas)</span>
       </Form>
     </Modal>
   );

--- a/client/src/components/modules/TeamCard.js
+++ b/client/src/components/modules/TeamCard.js
@@ -54,6 +54,7 @@ export default function TeamCard({
               </>
             )}
           </div>
+          {seedName && seedNum && <div className="TeamCard-group">{`${seedName} Seed (#${seedNum})`}</div>}
           {group && <div className="TeamCard-group">{group}</div>}
         </div>
         {players

--- a/client/src/components/modules/UserCard.js
+++ b/client/src/components/modules/UserCard.js
@@ -25,6 +25,7 @@ export default function UserCard({
   if (user.donations >= 10 && user.cardImage) {
     cardStyle.backgroundImage = `linear-gradient(#13141577, #2e313577), url("/public/cards/${user.cardImage}")`;
   }
+  const seedInfo = stats && stats.seedName ? `${stats.seedName} Seed (#${stats.seedNum})${stats.group ? `, Group ${stats.group}` : ""}` : "";
 
   return (
     <div>
@@ -68,6 +69,7 @@ export default function UserCard({
             )}
           </div>
           {extra && <div className="UserCard-bot">{extra}</div>}
+          {seedInfo && <div className="UserCard-bot">{seedInfo}</div>}
         </div>
         {canEdit && (
           <div>

--- a/client/src/components/pages/NewTourneyHome.js
+++ b/client/src/components/pages/NewTourneyHome.js
@@ -58,6 +58,7 @@ function NewTourneyHome({ tourney, user, setUser, setLoginAttention }) {
         countries: data.countries || [],
         flags: data.flags || [],
         lobbyMaxSignups: data.lobbyMaxSignups || 8,
+        blacklist: (data.blacklist || []).toString(),
       });
     })();
   }, []);
@@ -161,6 +162,7 @@ function NewTourneyHome({ tourney, user, setUser, setLoginAttention }) {
     console.log(settingsData);
     const res = await post("/api/tournament", {
       ...settingsData,
+      blacklist: settingsData.blacklist.split(",").map(x => Number.parseInt(x)).filter(x => x),
       tourney,
     });
     setShowSettings(false);

--- a/client/src/components/pages/Players.js
+++ b/client/src/components/pages/Players.js
@@ -160,7 +160,7 @@ export default function Players({ tourney, user }) {
       rank: (x, y) =>
         x.players.reduce((sum, p) => sum + p.rank, 0) / x.players.length -
         y.players.reduce((sum, p) => sum + p.rank, 0) / y.players.length,
-      seed: (x, y) => (x.seedNum || 0) - (y.seedNum || 0),
+      seed: (x, y) => (x.seedNum || Infinity) - (y.seedNum || Infinity),
     };
 
     const sortFn = sortFunctions[sortMethod];
@@ -263,8 +263,9 @@ export default function Players({ tourney, user }) {
           return t;
         })
       );
+      message.success(`Successfully edited team stats`);
     } catch (e) {
-      message.error(`Couldn't get team stats: ${e}`);
+      message.error(`Failed to edit team stats: ${e}`);
     }
   };
 
@@ -290,8 +291,9 @@ export default function Players({ tourney, user }) {
           return t;
         })
       );
+      message.success(`Successfully edited player stats`);
     } catch (e) {
-      message.error(`Something went wrong: ${e}`);
+      message.error(`Failed to edit player stats: ${e}`);
     }
   };
 

--- a/client/src/components/pages/Players.js
+++ b/client/src/components/pages/Players.js
@@ -532,12 +532,6 @@ export default function Players({ tourney, user }) {
         {mode === "players"
           ? players.map((player) => {
               const stats = player.stats.filter((t) => t.tourney == tourney)[0];
-              const extra =
-                stats && stats.seedName
-                  ? `${stats.seedName} Seed (#${stats.seedNum})${
-                      stats.group ? `, Group ${stats.group}` : ""
-                    }`
-                  : "";
 
               return (
                 <UserCard
@@ -550,7 +544,6 @@ export default function Players({ tourney, user }) {
                   stats={stats}
                   rankRange={rankRange}
                   showGroups={hasGroups}
-                  extra={extra}
                   flags={flags}
                 />
               );

--- a/client/src/components/pages/Schedule.js
+++ b/client/src/components/pages/Schedule.js
@@ -9,6 +9,8 @@ import AddTag from "../modules/AddTag";
 import Qualifiers from "../modules/Qualifiers";
 import SubmitWarmupModal from "../modules/SubmitWarmupModal";
 import "./Schedule.css";
+import UserCard from "../modules/UserCard";
+import TeamCard from "../modules/TeamCard";
 
 import {
   Layout,
@@ -23,6 +25,7 @@ import {
   Tooltip,
   Select,
   Radio,
+  Popover,
 } from "antd";
 import { UserAuth } from "../../permissions/UserAuth";
 import { UserRole } from "../../permissions/UserRole";
@@ -312,17 +315,22 @@ class Schedule extends Component {
     }
 
     const stats = this.getStats(p);
-
-    const title =
-      stats && stats.seedName && stats.seedNum ? `${stats.seedName} Seed (#${stats.seedNum})` : "";
+    const thePlayerOrTeam = this.getInfo(p);
+    
+    const popoverContent = thePlayerOrTeam._id ?
+                             (thePlayerOrTeam.players ?
+                               <TeamCard key={thePlayerOrTeam._id} {...thePlayerOrTeam} /> :
+                               <UserCard key={thePlayerOrTeam.userid} user={thePlayerOrTeam} stats={stats} />
+                             ) :
+                             (`No info available`);
 
     return (
-      <Tooltip title={title}>
+      <Popover content={popoverContent} placement="right">
         <span className="Players-name">
           <FlagIcon size={14} code={this.getInfo(p).country} customIcon={this.getInfo(p).icon} />
           {p}
         </span>
-      </Tooltip>
+      </Popover>
     );
   };
 

--- a/client/src/components/pages/Stats.js
+++ b/client/src/components/pages/Stats.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import "./Stats.css";
-import { get, post, prettifyTourney, hasAccess, getStage } from "../../utilities";
+import { get, post, prettifyTourney, hasAccess, getStageWithVisibleStats } from "../../utilities";
 import { Layout, Table, Menu, Form, Switch, message, Button, InputNumber, Spin, Tooltip, Radio } from "antd";
 import { PlusOutlined, MinusOutlined } from "@ant-design/icons";
 const { Content } = Layout;
@@ -213,7 +213,7 @@ export default function Stats({ tourney, user }) {
     if (state.refetchDataInProgress) return;
     setState({ ...state, refetchDataInProgress: true });
 
-    const [tourneyModel, currentSelectedStage] = await getStage(tourney);
+    const [tourneyModel, currentSelectedStage] = await getStageWithVisibleStats(tourney);
 
     const [players, teams, stageMaps, stageStats, matches] = await Promise.all([
       get("/api/players", { tourney }),

--- a/client/src/components/pages/Stats.js
+++ b/client/src/components/pages/Stats.js
@@ -1,13 +1,15 @@
 import React, { useState, useEffect } from "react";
 import "./Stats.css";
 import { get, post, prettifyTourney, hasAccess, getStageWithVisibleStats } from "../../utilities";
-import { Layout, Table, Menu, Form, Switch, message, Button, InputNumber, Spin, Tooltip, Radio } from "antd";
+import { Layout, Table, Menu, Form, Switch, message, Button, InputNumber, Spin, Tooltip, Radio, Popover } from "antd";
 import { PlusOutlined, MinusOutlined } from "@ant-design/icons";
 const { Content } = Layout;
 const { Column, ColumnGroup } = Table;
 import AddPlayerModal from "../modules/AddPlayerModal";
 import FlagIcon from "../modules/FlagIcon";
 import StageSelector from "../modules/StageSelector";
+import UserCard from "../modules/UserCard";
+import TeamCard from "../modules/TeamCard";
 
 export default function Stats({ tourney, user }) {
   const [state, setState] = useState({
@@ -463,13 +465,13 @@ export default function Stats({ tourney, user }) {
   const getTeamLabel = (teamName) => {
     const theTeam = state.teams.get(teamName);
     if (theTeam) {
-      const tooltipString = theTeam.seedName && theTeam.seedNum ? `${theTeam.seedName} Seed (#${theTeam.seedNum})` : "";
+      const popoverContent = (<TeamCard key={theTeam._id} {...theTeam} />);
 
       return (
         <div>
-          <Tooltip title={tooltipString}>
+          <Popover content={popoverContent} placement="right">
             <FlagIcon size={16} customIcon={theTeam.icon} code={theTeam.country} /> {teamName}
-          </Tooltip>
+          </Popover>
         </div>
       );
     } else return teamName;
@@ -480,15 +482,13 @@ export default function Stats({ tourney, user }) {
 
     if (thePlayer) {
       const playerTourneyStats = thePlayer.stats.find(stats => stats.tourney === tourney);
-      const seedName = playerTourneyStats?.seedName;
-      const seedNum = playerTourneyStats?.seedNum;
-      const tooltipString = seedName && seedNum ? `${seedName} Seed (#${seedNum})` : "";
+      const popoverContent = (<UserCard key={thePlayer._id} user={thePlayer} stats={playerTourneyStats} />);
 
       return (
         <div>
-          <Tooltip title={tooltipString}>
+          <Popover content={popoverContent} placement="right">
             <FlagIcon size={16} code={thePlayer.country} /> {thePlayer.username}
-          </Tooltip>
+          </Popover>
         </div>
       );
     } else return userId;

--- a/client/src/components/pages/Stats.js
+++ b/client/src/components/pages/Stats.js
@@ -463,9 +463,13 @@ export default function Stats({ tourney, user }) {
   const getTeamLabel = (teamName) => {
     const theTeam = state.teams.get(teamName);
     if (theTeam) {
+      const tooltipString = theTeam.seedName && theTeam.seedNum ? `${theTeam.seedName} Seed (#${theTeam.seedNum})` : "";
+
       return (
         <div>
-          <FlagIcon size={16} customIcon={theTeam.icon} code={theTeam.country} /> {teamName}
+          <Tooltip title={tooltipString}>
+            <FlagIcon size={16} customIcon={theTeam.icon} code={theTeam.country} /> {teamName}
+          </Tooltip>
         </div>
       );
     } else return teamName;

--- a/client/src/utilities.js
+++ b/client/src/utilities.js
@@ -71,6 +71,23 @@ export async function getStage(tourneyId) {
   return [tourney, { ...current, index: curIndex }];
 }
 
+// returns the tournament and the current stage indicated bythe page URL
+export async function getStageWithVisibleStats(tourneyId) {
+  const tourney = await get("/api/tournament", { tourney: tourneyId });
+  if (!tourney.stages || tourney.stages.length === 0) return [tourney, {}];
+
+  let curIndex;
+  if (!location.hash.substring(1)) {
+    curIndex = Math.max(0, tourney.stages.filter((s) => s.statsVisible).length - 1);
+  } else {
+    curIndex = parseInt(location.hash.substring(1)) || 0;
+  }
+
+  const current = tourney.stages[curIndex] || tourney.stages[0];
+
+  return [tourney, { ...current, index: curIndex }];
+}
+
 export function prettifyTourney(tourney) {
   return `${tourney.replace("_", " ").toUpperCase()}`;
 }

--- a/server/models/tournament.ts
+++ b/server/models/tournament.ts
@@ -19,6 +19,7 @@ interface ITournament {
   countries: string[];
   flags: string[];
   lobbyMaxSignups: number;
+  blacklist: number[];
 }
 
 const Tournament = new Schema<ITournament>({
@@ -40,6 +41,7 @@ const Tournament = new Schema<ITournament>({
   countries: [String],
   flags: [String],
   lobbyMaxSignups: Number,
+  blacklist: [Number],
 });
 
 export { TourneyStage, ITournament };


### PR DESCRIPTION
![Screenshot 2023-02-16 05 14 13](https://user-images.githubusercontent.com/4967258/219356978-1455394d-a188-42fb-a478-532b5186c6fa.png)

![Screenshot 2023-02-16 06 48 20](https://user-images.githubusercontent.com/4967258/219357172-e45f8b2f-f1f7-4ad9-a883-8f9934bb90ca.png)

bonus changes:
- stats page defaults to latest stage with visibility enabled
- players page sorted by seed shows unseeded at the bottom
- blacklist feature (banned player ids can be specified in tournament settings)