### PR TITLE
fix stuff

### DIFF
--- a/client/src/components/modules/Navbar.js
+++ b/client/src/components/modules/Navbar.js
@@ -214,7 +214,7 @@ function Navbar(props) {
   }, [user]);
 
   const handleOk = async () => {
-    if (!formData.discord || formData.timezone === undefined) {
+    if (formData.timezone === undefined) {
       return message.error("You must fill out these fields");
     }
 

--- a/client/src/components/pages/Stats.js
+++ b/client/src/components/pages/Stats.js
@@ -57,7 +57,7 @@ export default function Stats({ tourney, user }) {
 
     // process, sort, and rank the stats for each map, while tracking overall stats
     for (const mapStats of state.stageStats.maps || []) {
-      const mod = state.stageMaps.find((stageMap) => stageMap.mapId === mapStats.mapId).mod;
+      const mod = state.stageMaps.find((stageMap) => stageMap.mapId === mapStats.mapId)?.mod;
       const sortedPlayerScores = [...mapStats.playerScores].sort((a, b) => b.score - a.score);
       const sortedTeamScores = [...mapStats.teamScores].sort((a, b) => b.score - a.score);
       const processedPlayerScores = [];


### PR DESCRIPTION
Fixed user modal not allowing form submission if the timezone or bg fields were updated. the `formData` which is initialized with the entire `user` data gets replaced with an object with just those two fields (I assume it's because the `Form` only has those two items). Since I took out `discord` field in the previous update, I should just remove it from the condition now. This makes it optional now, but if that's not desired I can change it to check for discordId instead. I dunno if we wanna enforce this outside of tourney registrations though.

Bonus: fixed stats page breaking if a map was not found in the mappool (in the case where mappool got updated with a new map after matches were played) (I had accounted for this before but I missed this spot :bonkeh:)